### PR TITLE
Release 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Release 3.3.0
+## Main Library Updates
+- Spring Boot to 4.0.7
+
+## Fixes
+- Fixed that `json-unit` and `json-path` was not used as transitive dependency. 
+
+
 # Release 3.2.0
 
 ## Bugfix

--- a/bdd-cucumber-gherkin-lib-core/build.gradle
+++ b/bdd-cucumber-gherkin-lib-core/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
     // Testing
     api(libs.bundles.cucumber)
-    implementation(libs.json.path)
-    implementation(libs.json.unit)
+    api(libs.json.path)
+    api(libs.json.unit)
     implementation(libs.testing.kotlin.test)
 }

--- a/bdd-cucumber-gherkin-lib-core/src/main/kotlin/com/ragin/bdd/cucumber/constants/BddLibConfigConstants.kt
+++ b/bdd-cucumber-gherkin-lib-core/src/main/kotlin/com/ragin/bdd/cucumber/constants/BddLibConfigConstants.kt
@@ -34,7 +34,7 @@ object BddLibConfigConstants {
 
     const val GLUE_PROPERTY_VALUES_REST_DATABASE = Core.GLUE_PROPERTY_VALUES_HOOKS_CORE +
             COMMA +
-            Rest.GLUE_PROPERTY_VALUES_GLUE_REST+
+            Rest.GLUE_PROPERTY_VALUES_GLUE_REST +
             COMMA +
             Database.GLUE_PROPERTY_VALUES_HOOKS_DATABASE +
             COMMA +

--- a/bdd-cucumber-gherkin-lib-core/src/main/kotlin/com/ragin/bdd/cucumber/core/ScenarioStateContext.kt
+++ b/bdd-cucumber-gherkin-lib-core/src/main/kotlin/com/ragin/bdd/cucumber/core/ScenarioStateContext.kt
@@ -1,7 +1,7 @@
 package com.ragin.bdd.cucumber.core
 
-import org.springframework.http.ResponseEntity
 import net.javacrumbs.jsonunit.core.Option
+import org.springframework.http.ResponseEntity
 
 object ScenarioStateContext {
     var latestResponse: ResponseEntity<String>? = null
@@ -51,11 +51,11 @@ object ScenarioStateContext {
         fileBasePath = ""
         urlBasePath = ""
         editableBody = ""
-        headerValues = hashMapOf()
-        jsonPathOptions = mutableListOf()
+        headerValues.clear()
+        jsonPathOptions.clear()
         bearerToken = defaultBearerToken
-        polling = Polling()
-        scenarioContextFileMap = hashMapOf()
+        polling.clear()
+        scenarioContextFileMap.clear()
     }
 
     fun resolveEntry(key: String): String {
@@ -85,5 +85,10 @@ object ScenarioStateContext {
     class Polling {
         var pollEverySeconds: Long = 0
         var numberOfPolls: Int = -1
+
+        fun clear() {
+            pollEverySeconds = 0
+            numberOfPolls = -1
+        }
     }
 }

--- a/bdd-cucumber-gherkin-lib/build.gradle
+++ b/bdd-cucumber-gherkin-lib/build.gradle
@@ -25,8 +25,8 @@ dependencies {
 
     // Testing-Libraries
     api(libs.bundles.cucumber)
-    implementation(libs.json.path)
-    implementation(libs.json.unit)
+    api(libs.json.path)
+    api(libs.json.unit)
     implementation(libs.testing.kotlin.test)
 
     // Tests

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@ plugins {
     alias(libs.plugins.sonarqube)
     alias(libs.plugins.jreleaser) apply(false)
     alias(libs.plugins.spring.boot) apply(false)
-    alias(libs.plugins.spring.boot.dependency.management)
     alias(libs.plugins.kotlin.jvm) apply(false)
     alias(libs.plugins.kotlin.spring) apply(false)
     alias(libs.plugins.kover)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,6 @@
 group=io.github.ragin-lundf
-version=3.2.0
+version=3.3.0
 jdk_version=25
-kotlin_version=2.3.21
 
 systemProp.sonar.host.url=https://sonarcloud.io/
 systemProp.sonar.organization=ragin-lundf-github

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,7 @@
 [versions]
 kotlin = "2.3.21"
-springBoot = "4.0.6"
+springBoot = "4.0.7"
 cucumber = "7.34.3"
-jackson = "3.1.3"
 testcontainers = "2.0.5"
 
 [libraries]
@@ -10,7 +9,7 @@ testcontainers = "2.0.5"
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 
 # --- Common Libs and Utils
-logging-logger = { module = "io.github.oshai:kotlin-logging-jvm", version = "8.0.03" }
+logging-logger = { module = "io.github.oshai:kotlin-logging-jvm", version = "8.0.4" }
 logging-slf4j = { module = "org.slf4j:slf4j-simple", version = "2.0.18" }
 
 commons-io = { module = "commons-io:commons-io", version = "2.22.0" }
@@ -36,7 +35,7 @@ spring-boot-starter-liquibase = { module = "org.springframework.boot:spring-boot
 
 # --- JSON
 json-path = { module = "com.jayway.jsonpath:json-path", version = "3.0.0" }
-json-unit = { module = "net.javacrumbs.json-unit:json-unit", version = "5.1.1" }
+json-unit = { module = "net.javacrumbs.json-unit:json-unit", version = "5.1.2" }
 
 # --- Cucumber
 cucumber-java = { module = "io.cucumber:cucumber-java", version.ref = "cucumber" }
@@ -49,12 +48,12 @@ testing-kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test-junit5" }
 testing-konsist = { module = "com.lemonappdev:konsist", version = "0.17.3" }
 
 # --- Jackson
-jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version = "2.21" }
-jackson-jaxb = { module = "tools.jackson.module:jackson-module-jaxb-annotations", version.ref = "jackson" }
-jackson-module-kotlin = { module = "tools.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
-jackson-module-blackbird = { module = "tools.jackson.module:jackson-module-blackbird", version.ref = "jackson" }
-jackson-dataformmat-yaml = { module = "tools.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
-jackson-dataformat-csv = { module = "tools.jackson.dataformat:jackson-dataformat-csv", version.ref = "jackson" }
+jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations" }
+jackson-jaxb = { module = "tools.jackson.module:jackson-module-jaxb-annotations" }
+jackson-module-kotlin = { module = "tools.jackson.module:jackson-module-kotlin" }
+jackson-module-blackbird = { module = "tools.jackson.module:jackson-module-blackbird" }
+jackson-dataformmat-yaml = { module = "tools.jackson.dataformat:jackson-dataformat-yaml" }
+jackson-dataformat-csv = { module = "tools.jackson.dataformat:jackson-dataformat-csv" }
 
 # --- HTTP Client
 httpclient = { module = "org.apache.httpcomponents.client5:httpclient5", version = "5.6.1" }
@@ -98,8 +97,7 @@ testcontainers = [
 jreleaser = { id = "org.jreleaser", version = "1.24.0" }
 sonarqube = { id = "org.sonarqube", version = "7.3.0.8198" }
 spring-boot = { id = "org.springframework.boot", version.ref = "springBoot" }
-spring-boot-dependency-management = { id = "io.spring.dependency-management", version = "1.1.7" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version = "0.9.8" }
-detekt = { id = "dev.detekt", version = "2.0.0-alpha.3" }
+detekt = { id = "dev.detekt", version = "2.0.0-alpha.4" }


### PR DESCRIPTION
## Main Library Updates
- Spring Boot to 4.0.7

## Fixes
- Fixed that `json-unit` and `json-path` was not used as transitive dependency. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Release**
  * Version 3.3.0 released with Spring Boot framework upgraded to 4.0.7.

* **Improvements**
  * JSON testing and path processing libraries are now exposed as public transitive dependencies for better downstream compatibility.

* **Chores**
  * Updated logging and testing framework library versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->